### PR TITLE
HermiT updates for OWLAPI 4.0.2-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+target

--- a/HermiT-mvn/pom.xml
+++ b/HermiT-mvn/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.hermit-reasoner</groupId>
   <artifactId>org.semanticweb.hermit</artifactId>
-  <version>1.3.8.2-SNAPSHOT</version>
+  <version>1.3.8.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>HermiT</name>
@@ -64,8 +64,8 @@
            <artifactId>maven-compiler-plugin</artifactId>
            <version>2.3.1</version>
            <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+               <source>1.7</source>
+               <target>1.7</target>
                <excludes>
                  <!-- exclude the protege dependency and the command line 
                  because we don't built a command line capable jar -->
@@ -152,7 +152,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-distribution</artifactId>
-      <version>3.4.5</version>
+      <version>4.0.2-SNAPSHOT</version>
     </dependency>
     
     <dependency>

--- a/examples/org/semanticweb/HermiT/examples/ChangeFormat.java
+++ b/examples/org/semanticweb/HermiT/examples/ChangeFormat.java
@@ -5,7 +5,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.io.OWLFunctionalSyntaxOntologyFormat;
+import org.semanticweb.owlapi.formats.FunctionalSyntaxDocumentFormat;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 
@@ -29,7 +29,8 @@ public class ChangeFormat {
         // Now we create a buffered stream since the ontology manager can then write to that stream. 
         BufferedOutputStream outputStream=new BufferedOutputStream(new FileOutputStream(newOntologyFile));
         // We use the same format as for the input ontology.
-        manager.saveOntology(ontology, new OWLFunctionalSyntaxOntologyFormat(), outputStream);
+        manager.saveOntology(ontology, new FunctionalSyntaxDocumentFormat(),
+                outputStream);
         // Now the ontology should be in the ontologies subfolder (you Java IDE, e.g., Eclipse, 
         // might have to refresh its view of files in the file system) before the file is visible.  
         System.out.println("The ontology in examples/ontologies/pizza.fss.owl should now contain all axioms from pizza.owl in functional style syntax (you might need to refresh the IDE file view). ");

--- a/examples/org/semanticweb/HermiT/examples/MaterialiseInferences.java
+++ b/examples/org/semanticweb/HermiT/examples/MaterialiseInferences.java
@@ -104,7 +104,7 @@ public class MaterialiseInferences {
         OWLOntology inferredAxiomsOntology=manager.createOntology();
         // Now we use the inferred ontology generator to fill the ontology. That might take some 
         // time since it involves possibly a lot of calls to the reasoner.    
-        iog.fillOntology(manager, inferredAxiomsOntology);
+        iog.fillOntology(manager.getOWLDataFactory(), inferredAxiomsOntology);
         // Now the axioms are computed and added to the ontology, but we still have to save 
         // the ontology into a file. Since we cannot write to relative files, we have to resolve the 
         // relative path to an absolute one in an OS independent form. We do this by (virtually) creating a 

--- a/src/org/semanticweb/HermiT/Reasoner.java
+++ b/src/org/semanticweb/HermiT/Reasoner.java
@@ -79,6 +79,7 @@ import org.semanticweb.HermiT.structural.ReducedABoxOnlyClausification;
 import org.semanticweb.HermiT.tableau.InterruptFlag;
 import org.semanticweb.HermiT.tableau.ReasoningTaskDescription;
 import org.semanticweb.HermiT.tableau.Tableau;
+import org.semanticweb.owlapi.formats.PrefixDocumentFormat;
 import org.semanticweb.owlapi.model.AddAxiom;
 import org.semanticweb.owlapi.model.AddOntologyAnnotation;
 import org.semanticweb.owlapi.model.AxiomType;
@@ -93,6 +94,7 @@ import org.semanticweb.owlapi.model.OWLDataProperty;
 import org.semanticweb.owlapi.model.OWLDataPropertyExpression;
 import org.semanticweb.owlapi.model.OWLDatatype;
 import org.semanticweb.owlapi.model.OWLDeclarationAxiom;
+import org.semanticweb.owlapi.model.OWLDocumentFormat;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLException;
 import org.semanticweb.owlapi.model.OWLFunctionalObjectPropertyAxiom;
@@ -110,7 +112,6 @@ import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyChange;
 import org.semanticweb.owlapi.model.OWLOntologyChangeListener;
-import org.semanticweb.owlapi.model.OWLOntologyFormat;
 import org.semanticweb.owlapi.model.OWLSubObjectPropertyOfAxiom;
 import org.semanticweb.owlapi.model.OWLSubPropertyChainOfAxiom;
 import org.semanticweb.owlapi.model.OWLTransitiveObjectPropertyAxiom;
@@ -139,7 +140,6 @@ import org.semanticweb.owlapi.reasoner.impl.OWLNamedIndividualNodeSet;
 import org.semanticweb.owlapi.reasoner.impl.OWLObjectPropertyNode;
 import org.semanticweb.owlapi.reasoner.impl.OWLObjectPropertyNodeSet;
 import org.semanticweb.owlapi.util.Version;
-import org.semanticweb.owlapi.vocab.PrefixOWLOntologyFormat;
 
 /**
  * Answers queries about the logical implications of a particular knowledge base. A Reasoner is associated with a single knowledge base, which is "loaded" when the reasoner is constructed. By default a full classification of all atomic terms in the knowledge base is also performed at this time (which can take quite a while for large or complex ontologies), but this behavior can be disabled as a part of the Reasoner configuration. Internal details of the loading and reasoning algorithms can be configured in the Reasoner constructor and do not change over the lifetime of the Reasoner object---internal data structures and caches are optimized for a particular configuration. By default, HermiT will use the set of options which provide optimal performance.
@@ -239,9 +239,9 @@ public class Reasoner implements OWLReasoner {
         m_prefixes.declareInternalPrefixes(individualIRIs,anonIndividualIRIs);
         m_prefixes.declareDefaultPrefix(m_dlOntology.getOntologyIRI()+"#");
         // declare prefixes as used in the ontology if possible
-        OWLOntologyFormat format=m_rootOntology.getOWLOntologyManager().getOntologyFormat(m_rootOntology);
-        if (format instanceof PrefixOWLOntologyFormat) {
-            PrefixOWLOntologyFormat prefixFormat=(PrefixOWLOntologyFormat)format;
+        OWLDocumentFormat format=m_rootOntology.getOWLOntologyManager().getOntologyFormat(m_rootOntology);
+        if (format instanceof PrefixDocumentFormat) {
+        	PrefixDocumentFormat prefixFormat=(PrefixDocumentFormat)format;
             for (String prefixName : prefixFormat.getPrefixName2PrefixMap().keySet()) {
                 String prefix=prefixFormat.getPrefixName2PrefixMap().get(prefixName);
                 if (m_prefixes.getPrefixName(prefix)==null)

--- a/src/org/semanticweb/HermiT/Reasoner.java
+++ b/src/org/semanticweb/HermiT/Reasoner.java
@@ -148,6 +148,7 @@ public class Reasoner implements OWLReasoner {
     protected final OntologyChangeListener m_ontologyChangeListener;
     protected final Configuration m_configuration;
     protected final OWLOntology m_rootOntology;
+    protected final OWLDataFactory df;
     protected final List<OWLOntologyChange> m_pendingChanges;
     protected final Collection<DescriptionGraph> m_descriptionGraphs;
     protected final InterruptFlag m_interruptFlag;
@@ -201,6 +202,7 @@ public class Reasoner implements OWLReasoner {
         m_ontologyChangeListener=new OntologyChangeListener();
         m_configuration=configuration;
         m_rootOntology=rootOntology;
+        df=m_rootOntology.getOWLOntologyManager().getOWLDataFactory();
         m_pendingChanges=new ArrayList<OWLOntologyChange>();
         m_rootOntology.getOWLOntologyManager().addOntologyChangeListener(m_ontologyChangeListener);
         if (descriptionGraphs==null)
@@ -290,7 +292,7 @@ public class Reasoner implements OWLReasoner {
         m_interruptFlag.interrupt();
     }
     public OWLDataFactory getDataFactory() {
-        return m_rootOntology.getOWLOntologyManager().getOWLDataFactory();
+        return df;
     }
 
     // Accessor methods of the OWL API
@@ -1642,7 +1644,7 @@ public class Reasoner implements OWLReasoner {
         if (!m_isConsistent)
             return true;
         if (!isDefined(namedIndividual))
-            return getEquivalentClasses(type).contains(m_rootOntology.getOWLOntologyManager().getOWLDataFactory().getOWLThing());
+            return getEquivalentClasses(type).contains(df.getOWLThing());
         else {
             if (type instanceof OWLClass) {
                 if (direct)

--- a/src/org/semanticweb/HermiT/cli/CommandLine.java
+++ b/src/org/semanticweb/HermiT/cli/CommandLine.java
@@ -733,10 +733,10 @@ public class CommandLine {
                     long startTime=System.currentTimeMillis();
                     OWLOntologyManager ontologyManager=OWLManager.createOWLOntologyManager();
                     if (ont.isAbsolute()) {
-                        URI uri=URI.create(ont.getStart());
+                        URI uri=URI.create(ont.getNamespace());
                         String scheme = uri.getScheme();
                         if (scheme!=null && scheme.equalsIgnoreCase("file")) {
-                            File file=new File(URI.create(ont.getStart()));
+                            File file=new File(URI.create(ont.getNamespace()));
                             if (file.isDirectory()) {
                                 OWLOntologyIRIMapper mapper=new AutoIRIMapper(file, false);
                                 ontologyManager.addIRIMapper(mapper);

--- a/src/org/semanticweb/HermiT/structural/OWLClausification.java
+++ b/src/org/semanticweb/HermiT/structural/OWLClausification.java
@@ -122,6 +122,8 @@ import org.semanticweb.owlapi.model.SWRLSameIndividualAtom;
 import org.semanticweb.owlapi.model.SWRLVariable;
 import org.semanticweb.owlapi.util.OWLAxiomVisitorAdapter;
 
+import com.google.common.base.Optional;
+
 public class OWLClausification {
     protected static final Variable X=Variable.create("X");
     protected static final Variable Y=Variable.create("Y");
@@ -134,7 +136,8 @@ public class OWLClausification {
     }
     public Object[] preprocessAndClausify(OWLOntology rootOntology,Collection<DescriptionGraph> descriptionGraphs) {
         OWLDataFactory factory=rootOntology.getOWLOntologyManager().getOWLDataFactory();
-        String ontologyIRI=rootOntology.getOntologyID().getDefaultDocumentIRI()==null ? "urn:hermit:kb" : rootOntology.getOntologyID().getDefaultDocumentIRI().toString();
+        Optional<IRI> defaultDocumentIRI = rootOntology.getOntologyID().getDefaultDocumentIRI();
+        String ontologyIRI=defaultDocumentIRI.isPresent()?defaultDocumentIRI.get().toString(): "urn:hermit:kb" ;
         Collection<OWLOntology> importClosure=rootOntology.getImportsClosure();
         OWLAxioms axioms=new OWLAxioms();
         OWLNormalization normalization=new OWLNormalization(factory,axioms,0);

--- a/src/org/semanticweb/HermiT/structural/OWLNormalization.java
+++ b/src/org/semanticweb/HermiT/structural/OWLNormalization.java
@@ -123,6 +123,7 @@ import org.semanticweb.owlapi.model.SWRLObjectVisitor;
 import org.semanticweb.owlapi.model.SWRLRule;
 import org.semanticweb.owlapi.model.SWRLSameIndividualAtom;
 import org.semanticweb.owlapi.model.SWRLVariable;
+import org.semanticweb.owlapi.model.parameters.Imports;
 
 /**
  * This class implements the structural transformation from our new tableau paper. This transformation departs in the following way from the paper: it keeps the concepts of the form \exists R.{ a_1, ..., a_n }, \forall R.{ a_1, ..., a_n }, and \forall R.\neg { a } intact. These concepts are then clausified in a more efficient way.
@@ -152,10 +153,10 @@ public class OWLNormalization {
         // concepts -- that is, each OWLClassExpression in an entry contributes a
         // disjunct. It is thus not really inclusions, but rather a disjunction
         // of concepts that represents an inclusion axiom.
-        m_axioms.m_classes.addAll(ontology.getClassesInSignature(true));
-        m_axioms.m_objectProperties.addAll(ontology.getObjectPropertiesInSignature(true));
-        m_axioms.m_dataProperties.addAll(ontology.getDataPropertiesInSignature(true));
-        m_axioms.m_namedIndividuals.addAll(ontology.getIndividualsInSignature(true));
+        m_axioms.m_classes.addAll(ontology.getClassesInSignature(Imports.INCLUDED));
+        m_axioms.m_objectProperties.addAll(ontology.getObjectPropertiesInSignature(Imports.INCLUDED));
+        m_axioms.m_dataProperties.addAll(ontology.getDataPropertiesInSignature(Imports.INCLUDED));
+        m_axioms.m_namedIndividuals.addAll(ontology.getIndividualsInSignature(Imports.INCLUDED));
         processAxioms(ontology.getLogicalAxioms());
     }
     public void processAxioms(Collection<? extends OWLAxiom> axioms) {

--- a/test/org/semanticweb/HermiT/owl_wg_tests/AbstractTest.java
+++ b/test/org/semanticweb/HermiT/owl_wg_tests/AbstractTest.java
@@ -26,7 +26,7 @@ import java.io.FileWriter;
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
 
-import org.coode.owlapi.functionalrenderer.OWLFunctionalSyntaxRenderer;
+import org.semanticweb.owlapi.functional.renderer.OWLFunctionalSyntaxRenderer;
 import org.semanticweb.HermiT.Configuration;
 import org.semanticweb.HermiT.Reasoner;
 import org.semanticweb.owlapi.apibinding.OWLManager;

--- a/test/org/semanticweb/HermiT/owl_wg_tests/WGTestDescriptor.java
+++ b/test/org/semanticweb/HermiT/owl_wg_tests/WGTestDescriptor.java
@@ -138,7 +138,7 @@ public class WGTestDescriptor {
 
     protected String getIdentifier(Multimap<OWLDataPropertyExpression,OWLLiteral> dps,OWLDataFactory df) throws InvalidWGTestException {
         Collection<OWLLiteral> identifiers=dps.get(df.getOWLDataProperty(IRI.create(WGTestRegistry.URI_BASE+"identifier")));
-        if (identifiers==null || identifiers.isEmpty())
+        if ( identifiers.isEmpty())
             throw new InvalidWGTestException("Test does not have an identifier.");
         if (identifiers.size()!=1)
             throw new InvalidWGTestException("Test has more than one identifier.");
@@ -147,7 +147,7 @@ public class WGTestDescriptor {
 
     protected Status getStatus(Multimap<OWLObjectPropertyExpression,OWLIndividual> ops,OWLDataFactory df) throws InvalidWGTestException {
         Collection<OWLIndividual> statuses=ops.get(df.getOWLObjectProperty(IRI.create(WGTestRegistry.URI_BASE+"status")));
-        if (statuses==null || statuses.isEmpty())
+        if (statuses.isEmpty())
             return null;
         else if (statuses.size()>1)
             throw new InvalidWGTestException("The test "+testID+" has more than one status.");
@@ -185,20 +185,18 @@ public class WGTestDescriptor {
     protected EnumSet<Species> getSpecies(Multimap<OWLObjectPropertyExpression,OWLIndividual> ops,OWLDataFactory df) throws InvalidWGTestException {
         EnumSet<Species> species=EnumSet.noneOf(Species.class);
         Collection<OWLIndividual> specs=ops.get(df.getOWLObjectProperty(IRI.create(WGTestRegistry.URI_BASE+"species")));
-        if (specs!=null) {
-            nextItem: for (OWLIndividual s : specs) {
-                if (s.isAnonymous()) {
-                    throw new InvalidWGTestException("Invalid test error: Test individuals must be named. ");
-                }
-                IRI speciesIRI=s.asOWLNamedIndividual().getIRI();
-                for (Species spc : Species.values()) {
-                    if (speciesIRI.equals(spc.uri)) {
-                        species.add(spc);
-                        continue nextItem;
-                    }
-                }
-                throw new InvalidWGTestException("The test "+testID+" has an invalid species "+speciesIRI.toString()+".");
+        nextItem: for (OWLIndividual s : specs) {
+            if (s.isAnonymous()) {
+                throw new InvalidWGTestException("Invalid test error: Test individuals must be named. ");
             }
+            IRI speciesIRI=s.asOWLNamedIndividual().getIRI();
+            for (Species spc : Species.values()) {
+                if (speciesIRI.equals(spc.uri)) {
+                    species.add(spc);
+                    continue nextItem;
+                }
+            }
+            throw new InvalidWGTestException("The test "+testID+" has an invalid species "+speciesIRI.toString()+".");
         }
         return species;
     }
@@ -206,19 +204,17 @@ public class WGTestDescriptor {
     protected EnumSet<Semantics> getSemantics(Multimap<OWLObjectPropertyExpression,OWLIndividual> ops,OWLDataFactory df) throws InvalidWGTestException {
         EnumSet<Semantics> semantics=EnumSet.noneOf(Semantics.class);
         Collection<OWLIndividual> sems=ops.get(df.getOWLObjectProperty(IRI.create(WGTestRegistry.URI_BASE+"semantics")));
-        if (sems!=null) {
-            nextItem: for (OWLIndividual s : sems) {
-                if (s.isAnonymous())
-                    throw new InvalidWGTestException("Invalid test error: Test individuals must be named. ");
-                IRI semanticsIRI=s.asOWLNamedIndividual().getIRI();
-                for (Semantics sem : Semantics.values()) {
-                    if (semanticsIRI.equals(sem.uri)) {
-                        semantics.add(sem);
-                        continue nextItem;
-                    }
+        nextItem: for (OWLIndividual s : sems) {
+            if (s.isAnonymous())
+                throw new InvalidWGTestException("Invalid test error: Test individuals must be named. ");
+            IRI semanticsIRI=s.asOWLNamedIndividual().getIRI();
+            for (Semantics sem : Semantics.values()) {
+                if (semanticsIRI.equals(sem.uri)) {
+                    semantics.add(sem);
+                    continue nextItem;
                 }
-                throw new InvalidWGTestException("The test "+testID+" has an invalid semantics "+semanticsIRI.toString()+".");
             }
+            throw new InvalidWGTestException("The test "+testID+" has an invalid semantics "+semanticsIRI.toString()+".");
         }
         return semantics;
     }
@@ -226,19 +222,17 @@ public class WGTestDescriptor {
     protected EnumSet<Semantics> getNotSemantics(Multimap<OWLObjectPropertyExpression,OWLIndividual> nops,OWLDataFactory df) throws InvalidWGTestException {
         EnumSet<Semantics> notSemantics=EnumSet.noneOf(Semantics.class);
         Collection<OWLIndividual> nsems=nops.get(df.getOWLObjectProperty(IRI.create(WGTestRegistry.URI_BASE+"semantics")));
-        if (nsems!=null) {
-            nextItem: for (OWLIndividual s : nsems) {
-                if (s.isAnonymous())
-                    throw new InvalidWGTestException("Invalid test error: Test individuals must be named. ");
-                IRI semanticsIRI=s.asOWLNamedIndividual().getIRI();
-                for (Semantics sem : Semantics.values()) {
-                    if (semanticsIRI.equals(sem.uri)) {
-                        notSemantics.add(sem);
-                        continue nextItem;
-                    }
+        nextItem: for (OWLIndividual s : nsems) {
+            if (s.isAnonymous())
+                throw new InvalidWGTestException("Invalid test error: Test individuals must be named. ");
+            IRI semanticsIRI=s.asOWLNamedIndividual().getIRI();
+            for (Semantics sem : Semantics.values()) {
+                if (semanticsIRI.equals(sem.uri)) {
+                    notSemantics.add(sem);
+                    continue nextItem;
                 }
-                throw new InvalidWGTestException("The test "+testID+" has an invalid not semantics "+semanticsIRI.toString()+".");
             }
+            throw new InvalidWGTestException("The test "+testID+" has an invalid not semantics "+semanticsIRI.toString()+".");
         }
         return notSemantics;
     }
@@ -247,9 +241,9 @@ public class WGTestDescriptor {
         Multimap<OWLDataPropertyExpression,OWLLiteral> dps=EntitySearcher.getDataPropertyValues(testIndividual, testContainer);
         for (SerializationFormat format : SerializationFormat.values()) {
             Collection<OWLLiteral> premises=dps.get(format.premise);
-            if (premises!=null) {
-                if (premises.size()!=1)
-                    throw new InvalidWGTestException("Test "+testID+" has an incorrect number of premises.");
+            if(!premises.isEmpty()) {
+                if (premises.size()>1)
+                    throw new InvalidWGTestException("Test "+testID+" has an incorrect number of premises: "+premises);
                 StringDocumentSource source=new StringDocumentSource(premises.iterator().next().getLiteral());
                 try {
                     return manager.loadOntologyFromOntologyDocument(source);
@@ -272,7 +266,7 @@ public class WGTestDescriptor {
         Multimap<OWLDataPropertyExpression,OWLLiteral> dps=EntitySearcher.getDataPropertyValues(testIndividual,testContainer);
         for (SerializationFormat format : SerializationFormat.values()) {
             Collection<OWLLiteral> conclusions=dps.get(positive ? format.conclusion : format.nonconclusion);
-            if (conclusions!=null) {
+            if(!conclusions.isEmpty()) {
                 if (conclusions.size()!=1)
                     throw new InvalidWGTestException("Test "+testID+" has an incorrect number of "+(positive ? "" : "non")+"conclusions.");
                 StringDocumentSource source=new StringDocumentSource(conclusions.iterator().next().getLiteral());


### PR DESCRIPTION
This pull request fixes minor issues in HermiT code and relies on bug fixes made to OWLAPI

https://github.com/owlcs/owlapi/commit/af283fced701014e2e94f5e2b3f14eea17bbd161 Drop optimization in OWLLiteralImplInteger equals: padded integers must not be equal to unpadded integers.

https://github.com/owlcs/owlapi/issues/377 Functional parser parses cardinalities with more than one digit incorrectly

https://github.com/owlcs/owlapi/issues/378 Data property with xsd:integer range parsed as Object property (RDF/XML source)